### PR TITLE
Add Docker image publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  packages: write
+
+jobs:
+  publish:
+    name: Build & Push to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Publish image to GHCR
+        run: ./gradlew publishImageToExternalRegistry
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and push Docker image to GHCR on push to main
- Uses `GITHUB_TOKEN` for auth, tags as `latest`

## Test plan
- [ ] Merge to main and verify the workflow runs successfully
- [ ] Verify image appears at `ghcr.io/fathonyfath/tired-stack:latest`