### PR TITLE
Fix publish task name to match Ktor plugin API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v6
       - name: Publish image to GHCR
-        run: ./gradlew publishImageToExternalRegistry
+        run: ./gradlew publishImage
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Build and run via Docker:
 Push to GHCR (requires `GHCR_USERNAME` and `GHCR_TOKEN` env vars):
 
 ```bash
-./gradlew publishImageToExternalRegistry
+./gradlew publishImage
 ```
 
 ## Git Hooks


### PR DESCRIPTION
## Summary
- Fix Gradle task name from `publishImageToExternalRegistry` to `publishImage` in workflow and README

## Test plan
- [ ] CI publish workflow passes after merge