### PR TITLE
Enable ZGC as the default garbage collector

### DIFF
--- a/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
@@ -16,7 +16,7 @@ application {
     mainClass.set("dev.fathony.tired.MainKt")
     // Netty uses native libraries (e.g. epoll, SSL) loaded via System::loadLibrary.
     // JVM 25 restricts this by default — without this flag it warns and will eventually block.
-    applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
+    applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "-XX:+UseZGC")
 }
 
 ktor {


### PR DESCRIPTION
## Summary
- Add `-XX:+UseZGC` to `applicationDefaultJvmArgs` for low-latency GC across local and container environments

## Test plan
- [ ] `./gradlew run` starts with ZGC (verify with `-XX:+PrintFlagsFinal` or GC logs)
- [ ] RPS test shows no degradation