### PR TITLE
Add docker-compose and use JAVA_TOOL_OPTIONS for container JVM flags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    image: ghcr.io/fathonyfath/tired-stack:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - JAVA_TOOL_OPTIONS=--enable-native-access=ALL-UNNAMED -XX:+UseZGC -XX:MaxRAMPercentage=75.0 -XX:+UseContainerSupport
+    restart: unless-stopped

--- a/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
@@ -35,7 +35,7 @@ ktor {
             namespace = provider { "fathonyfath" },
         )
 
-        environmentVariable("JAVA_OPTS", "-XX:MaxRAMPercentage=75.0 -XX:+UseContainerSupport")
+        environmentVariable("JAVA_TOOL_OPTIONS", "--enable-native-access=ALL-UNNAMED -XX:+UseZGC -XX:MaxRAMPercentage=75.0 -XX:+UseContainerSupport")
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` for production deployment
- Switch from `JAVA_OPTS` to `JAVA_TOOL_OPTIONS` in both the convention plugin (`runDocker`) and docker-compose — the JVM reads this automatically regardless of entrypoint
- Includes `--enable-native-access=ALL-UNNAMED`, `-XX:+UseZGC`, `-XX:MaxRAMPercentage=75.0`, `-XX:+UseContainerSupport`

## Test plan
- [x] Verified container starts cleanly with "Picked up JAVA_TOOL_OPTIONS" in logs
- [x] No more Netty native access warning
- [x] RPS benchmark passes