### PR TITLE
Add SSE streaming demo with HTMX integration

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,9 +7,9 @@
         <compositeConfiguration>
           <compositeBuild compositeDefinitionSource="SCRIPT">
             <builds>
-              <build path="$PROJECT_DIR$/buildSrc" name="buildSrc">
+              <build path="$PROJECT_DIR$/gradle/plugins" name="plugins">
                 <projects>
-                  <project path="$PROJECT_DIR$/buildSrc" />
+                  <project path="$PROJECT_DIR$/gradle/plugins" />
                 </projects>
               </build>
             </builds>
@@ -19,7 +19,7 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/buildSrc" />
+            <option value="$PROJECT_DIR$/gradle/plugins" />
           </set>
         </option>
         <option name="myGradleHome" value="" />

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
+  </component>
+</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(libs.ktor.server.html.builder)
     implementation(libs.ktor.server.resources)
     implementation(libs.ktor.server.auto.head.response)
+    implementation(libs.ktor.server.sse)
     implementation(libs.ktor.htmx)
     implementation(libs.ktor.htmx.html)
     implementation(libs.ktor.server.htmx)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    image: ghcr.io/fathonyfath/tired-stack:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - JAVA_TOOL_OPTIONS=--enable-native-access=ALL-UNNAMED -XX:+UseZGC -XX:MaxRAMPercentage=75.0 -XX:+UseContainerSupport
+    restart: unless-stopped

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm" }
 ktor-server-html-builder = { module = "io.ktor:ktor-server-html-builder" }
 ktor-server-resources = { module = "io.ktor:ktor-server-resources" }
 ktor-server-auto-head-response = { module = "io.ktor:ktor-server-auto-head-response" }
+ktor-server-sse = { module = "io.ktor:ktor-server-sse" }
 ktor-htmx = { module = "io.ktor:ktor-htmx" }
 ktor-htmx-html = { module = "io.ktor:ktor-htmx-html" }
 ktor-server-htmx = { module = "io.ktor:ktor-server-htmx" }

--- a/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
@@ -35,7 +35,7 @@ ktor {
             namespace = provider { "fathonyfath" },
         )
 
-        environmentVariable("JAVA_OPTS", "-XX:MaxRAMPercentage=75.0 -XX:+UseContainerSupport")
+        environmentVariable("JAVA_TOOL_OPTIONS", "--enable-native-access=ALL-UNNAMED -XX:+UseZGC -XX:MaxRAMPercentage=75.0 -XX:+UseContainerSupport")
     }
 }
 

--- a/src/main/kotlin/dev/fathony/tired/Main.kt
+++ b/src/main/kotlin/dev/fathony/tired/Main.kt
@@ -4,10 +4,12 @@ import dev.fathony.tired.components.icon
 import dev.fathony.tired.layout.layout
 import dev.fathony.tired.layout.page
 import dev.fathony.tired.pages.htmxTest
+import dev.fathony.tired.pages.sseDemo
 import dev.fathony.tired.plugins.respondHtml
 import dev.fathony.tired.routing.Htmx
 import dev.fathony.tired.routing.HtmxTest
 import dev.fathony.tired.routing.Index
+import dev.fathony.tired.routing.SseDemo
 import io.ktor.htmx.HxResponseHeaders
 import io.ktor.http.ContentType
 import io.ktor.server.application.install
@@ -20,7 +22,12 @@ import io.ktor.server.resources.Resources
 import io.ktor.server.resources.get
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.sse.sse
+import io.ktor.sse.ServerSentEvent
 import io.ktor.utils.io.ExperimentalKtorApi
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
 
@@ -28,8 +35,8 @@ import kotlinx.html.stream.createHTML
 fun main() {
     embeddedServer(Netty, port = 3000) {
         install(AutoHeadResponse)
-//        install(HtmlMinifier)
         install(Resources)
+        install(SSE)
         routing {
             staticResources("/", "static")
             get<Index> {
@@ -75,6 +82,45 @@ fun main() {
                     }
                 }
             }
+            get<SseDemo> {
+                call.respondHtml {
+                    layout(name = "SSE Demo", css = true, js = true) {
+                        page(title = "SSE Demo") {
+                            sseDemo()
+                        }
+                    }
+                }
+            }
+            sse("/sse-demo/stream") {
+                send(ServerSentEvent(data = statusHtml("Connected — streaming will begin shortly...", StatusColor.GREEN), event = "status"))
+                delay(1.seconds)
+
+                for (i in 5 downTo 1) {
+                    send(ServerSentEvent(data = messageHtml("Countdown: $i..."), event = "message"))
+                    send(ServerSentEvent(data = statusHtml("Streaming — ${i - 1} events remaining", StatusColor.BLUE), event = "status"))
+                    delay(1.seconds)
+                }
+
+                send(ServerSentEvent(data = messageHtml("Done! Stream complete."), event = "message"))
+                send(ServerSentEvent(data = statusHtml("Stream finished", StatusColor.GRAY), event = "status"))
+            }
         }
     }.start(wait = true)
 }
+
+private fun messageHtml(text: String): String =
+    createHTML(prettyPrint = false).div(classes = "rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-800") {
+        +text
+    }
+
+private enum class StatusColor(val textClass: String, val dotClass: String) {
+    GREEN("text-green-600", "bg-green-500"),
+    BLUE("text-blue-600", "bg-blue-500"),
+    GRAY("text-gray-600", "bg-gray-500"),
+}
+
+private fun statusHtml(text: String, color: StatusColor): String =
+    createHTML(prettyPrint = false).span(classes = "inline-flex items-center gap-1.5 text-sm ${color.textClass}") {
+        span(classes = "h-2 w-2 rounded-full ${color.dotClass}") {}
+        +text
+    }

--- a/src/main/kotlin/dev/fathony/tired/Main.kt
+++ b/src/main/kotlin/dev/fathony/tired/Main.kt
@@ -26,10 +26,10 @@ import io.ktor.server.sse.SSE
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
 import io.ktor.utils.io.ExperimentalKtorApi
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalKtorApi::class)
 fun main() {
@@ -92,12 +92,22 @@ fun main() {
                 }
             }
             sse("/sse-demo/stream") {
-                send(ServerSentEvent(data = statusHtml("Connected — streaming will begin shortly...", StatusColor.GREEN), event = "status"))
+                send(
+                    ServerSentEvent(
+                        data = statusHtml("Connected — streaming will begin shortly...", StatusColor.GREEN),
+                        event = "status",
+                    ),
+                )
                 delay(1.seconds)
 
                 for (i in 5 downTo 1) {
                     send(ServerSentEvent(data = messageHtml("Countdown: $i..."), event = "message"))
-                    send(ServerSentEvent(data = statusHtml("Streaming — ${i - 1} events remaining", StatusColor.BLUE), event = "status"))
+                    send(
+                        ServerSentEvent(
+                            data = statusHtml("Streaming — ${i - 1} events remaining", StatusColor.BLUE),
+                            event = "status",
+                        ),
+                    )
                     delay(1.seconds)
                 }
 
@@ -109,17 +119,25 @@ fun main() {
 }
 
 private fun messageHtml(text: String): String =
-    createHTML(prettyPrint = false).div(classes = "rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-800") {
+    createHTML(
+        prettyPrint = false,
+    ).div(classes = "rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-800") {
         +text
     }
 
-private enum class StatusColor(val textClass: String, val dotClass: String) {
+private enum class StatusColor(
+    val textClass: String,
+    val dotClass: String,
+) {
     GREEN("text-green-600", "bg-green-500"),
     BLUE("text-blue-600", "bg-blue-500"),
     GRAY("text-gray-600", "bg-gray-500"),
 }
 
-private fun statusHtml(text: String, color: StatusColor): String =
+private fun statusHtml(
+    text: String,
+    color: StatusColor,
+): String =
     createHTML(prettyPrint = false).span(classes = "inline-flex items-center gap-1.5 text-sm ${color.textClass}") {
         span(classes = "h-2 w-2 rounded-full ${color.dotClass}") {}
         +text

--- a/src/main/kotlin/dev/fathony/tired/layout/Page.kt
+++ b/src/main/kotlin/dev/fathony/tired/layout/Page.kt
@@ -12,6 +12,7 @@ val defaultNavItems =
         NavItem("Home", "/"),
         NavItem("HTMX Test", "/htmx-test"),
         NavItem("HTMX", "/htmx"),
+        NavItem("SSE Demo", "/sse-demo"),
     )
 
 fun BODY.page(

--- a/src/main/kotlin/dev/fathony/tired/pages/SseDemo.kt
+++ b/src/main/kotlin/dev/fathony/tired/pages/SseDemo.kt
@@ -1,0 +1,38 @@
+package dev.fathony.tired.pages
+
+import kotlinx.html.*
+
+fun FlowContent.sseDemo() {
+    div {
+        h1(classes = "text-2xl font-bold") { +"SSE Streaming Demo" }
+        p(classes = "mt-2 text-gray-600") {
+            +"This page uses Server-Sent Events to stream HTML from the server in real time."
+        }
+        p(classes = "mt-1 text-gray-600") {
+            +"The server will send a countdown, then a final message — all pushed over a single persistent connection."
+        }
+
+        div(classes = "mt-6") {
+            attributes["hx-ext"] = "sse"
+            attributes["sse-connect"] = "/sse-demo/stream"
+
+            div {
+                id = "sse-messages"
+                attributes["sse-swap"] = "message"
+                attributes["hx-swap"] = "beforeend"
+                classes = setOf("space-y-2")
+            }
+
+            div(classes = "mt-4") {
+                id = "sse-status"
+                attributes["sse-swap"] = "status"
+                attributes["hx-swap"] = "innerHTML"
+
+                span(classes = "inline-flex items-center gap-1.5 text-sm text-amber-600") {
+                    span(classes = "h-2 w-2 rounded-full bg-amber-500 animate-pulse") {}
+                    +"Connecting..."
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/fathony/tired/routing/SseDemo.kt
+++ b/src/main/kotlin/dev/fathony/tired/routing/SseDemo.kt
@@ -1,0 +1,6 @@
+package dev.fathony.tired.routing
+
+import io.ktor.resources.Resource
+
+@Resource("/sse-demo")
+class SseDemo

--- a/web-assets/package-lock.json
+++ b/web-assets/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "htmx-ext-sse": "^2.2.4",
         "htmx.org": "^2.0.4"
       },
       "devDependencies": {
@@ -662,9 +663,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -682,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -702,9 +697,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -722,9 +714,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -929,9 +918,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -949,9 +935,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,9 +952,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -989,9 +969,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1740,6 +1717,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/htmx-ext-sse": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/htmx-ext-sse/-/htmx-ext-sse-2.2.4.tgz",
+      "integrity": "sha512-LJmxVhykyflBWgh5PvbRidcyuqMHlgfajmmzumvKctv9puvsufeH6OaejSMZTNTnEI8O2wXXn4ZZtBdpEMqmEQ==",
+      "dependencies": {
+        "htmx.org": "^2.0.2"
+      }
+    },
     "node_modules/htmx.org": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.10.tgz",
@@ -1968,9 +1953,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1992,9 +1974,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2016,9 +1995,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2040,9 +2016,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/web-assets/package.json
+++ b/web-assets/package.json
@@ -7,16 +7,17 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "htmx-ext-sse": "^2.2.4",
     "htmx.org": "^2.0.4"
   },
   "devDependencies": {
-    "prettier": "^3.5.3",
-    "tailwindcss": "^4.1.5",
     "@tailwindcss/postcss": "^4.1.5",
+    "esbuild": "^0.28.0",
+    "lucide-static": "^1.0.0",
     "postcss": "^8.5.3",
     "postcss-lightningcss": "^1.0.0",
-    "esbuild": "^0.28.0",
+    "prettier": "^3.5.3",
     "svg-sprite": "^2.0.4",
-    "lucide-static": "^1.0.0"
+    "tailwindcss": "^4.1.5"
   }
 }

--- a/web-assets/src/index.js
+++ b/web-assets/src/index.js
@@ -1,1 +1,2 @@
 import "htmx.org";
+import "htmx-ext-sse";


### PR DESCRIPTION
## Summary
- Adds `/sse-demo` page demonstrating Server-Sent Events streaming HTML fragments in real time
- Server pushes a countdown sequence (5→1) over a persistent connection using Ktor's SSE plugin
- HTMX's SSE extension (`htmx-ext-sse`) swaps incoming HTML into the DOM — no custom JavaScript needed
- Includes a status indicator and message list that update independently via separate SSE event channels

## Test plan
- [ ] Run the app and navigate to `/sse-demo`
- [ ] Verify the status changes from "Connecting..." → "Connected" → countdown → "Stream finished"
- [ ] Verify countdown messages appear one per second
- [ ] Verify the stream completes and no errors in browser console