### PR TITLE
Auto-format PRs and warn authors in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,34 +5,21 @@ on:
     branches: [main]
   pull_request:
 
-jobs:
-  ktlint:
-    name: Kotlin (ktlint)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Fetch base branch
-        if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }} --depth=1
-      - uses: actions/setup-java@v5
-        with:
-          java-version: "25"
-          distribution: temurin
-      - uses: gradle/actions/setup-gradle@v6
-      - name: ktlint (diff)
-        if: github.event_name == 'pull_request'
-        run: ./gradlew ktlintCheck -PdiffBase=origin/${{ github.base_ref }}
-      - name: ktlint (full)
-        if: github.event_name != 'pull_request'
-        run: ./gradlew ktlintCheck
+permissions:
+  contents: write
+  pull-requests: write
 
-  prettier:
-    name: JS & CSS (Prettier)
+jobs:
+  format:
+    name: Auto-format
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch base branch
-        if: github.event_name == 'pull_request'
         run: git fetch origin ${{ github.base_ref }} --depth=1
       - uses: actions/setup-java@v5
         with:
@@ -50,9 +37,83 @@ jobs:
           path: web-assets/node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('web-assets/package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-
-      - name: prettier (diff)
-        if: github.event_name == 'pull_request'
-        run: ./gradlew prettierCheck -PdiffBase=origin/${{ github.base_ref }}
-      - name: prettier (full)
-        if: github.event_name != 'pull_request'
+      - name: Run ktlintFormat
+        id: ktlint
+        continue-on-error: true
+        run: ./gradlew ktlintFormat -PdiffBase=origin/${{ github.base_ref }}
+      - name: Run prettierFormat
+        id: prettier
+        continue-on-error: true
+        run: ./gradlew prettierFormat -PdiffBase=origin/${{ github.base_ref }}
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit and push fixes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: auto-format with ktlint and prettier"
+          git push
+      - name: Warn author
+        if: steps.changes.outputs.has_changes == 'true' || steps.ktlint.outcome == 'failure' || steps.prettier.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fixed = '${{ steps.changes.outputs.has_changes }}' === 'true';
+            const ktlintFailed = '${{ steps.ktlint.outcome }}' === 'failure';
+            const prettierFailed = '${{ steps.prettier.outcome }}' === 'failure';
+
+            let body = '';
+            if (fixed && !ktlintFailed && !prettierFailed) {
+              body = '⚠️ Formatter auto-fixed some files in this PR. Please run `./gradlew format` locally before pushing next time.\n\nTip: run `./gradlew setupGitHooks` to enable the pre-commit hook that catches these automatically.';
+            } else if (ktlintFailed || prettierFailed) {
+              const failedTools = [ktlintFailed && 'ktlint', prettierFailed && 'prettier'].filter(Boolean).join(' and ');
+              body = `❌ ${failedTools} encountered errors that could not be auto-fixed. Please check the workflow logs and fix manually.`;
+              if (fixed) {
+                body += '\n\n⚠️ Some other issues were auto-fixed in a commit pushed to this branch.';
+              }
+            }
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });
+      - name: Fail if formatter errored
+        if: steps.ktlint.outcome == 'failure' || steps.prettier.outcome == 'failure'
+        run: exit 1
+
+  lint:
+    name: Check (push to main)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Cache Node.js download
+        uses: actions/cache@v5
+        with:
+          path: ~/.gradle/nodejs
+          key: node-${{ runner.os }}-24.15.0
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: web-assets/node_modules
+          key: npm-${{ runner.os }}-${{ hashFiles('web-assets/package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-
+      - name: ktlint
+        run: ./gradlew ktlintCheck
+      - name: prettier
         run: ./gradlew prettierCheck


### PR DESCRIPTION
## Summary
- On PRs: runs `ktlintFormat` + `prettierFormat`, commits fixes if any, and posts a comment warning the author to run `./gradlew format` locally (with a tip to enable the pre-commit hook via `./gradlew setupGitHooks`)
- Handles unfixable errors gracefully — commits what it can, warns about what it can't, and fails the job
- On push to main: runs check-only (no auto-fix)

## Test plan
- [x] Open a PR with a formatting violation and verify the bot commits a fix and comments
- [x] Open a PR with an unfixable error (e.g., line too long) and verify the job fails with a descriptive comment
- [x] Open a clean PR and verify no comment is posted