### PR TITLE
Add content-hashed asset filenames for cache busting

### DIFF
--- a/gradle/plugins/src/main/kotlin/tired.web-assets.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/tired.web-assets.gradle.kts
@@ -85,4 +85,5 @@ tasks.named<ProcessResources>("processResources") {
     from("${project.projectDir}/web-assets/$distDir/stylesheets") { into("static") }
     from("${project.projectDir}/web-assets/$distDir/scripts") { into("static") }
     from("${project.projectDir}/web-assets/dist/icons") { into("static") }
+    from("${project.projectDir}/web-assets/dist/manifest.json")
 }

--- a/src/main/kotlin/dev/fathony/tired/assets/AssetManifest.kt
+++ b/src/main/kotlin/dev/fathony/tired/assets/AssetManifest.kt
@@ -1,0 +1,19 @@
+package dev.fathony.tired.assets
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+object AssetManifest {
+    private val entries: Map<String, String> by lazy {
+        val json = AssetManifest::class.java.getResource("/manifest.json")?.readText()
+        if (json != null) {
+            val obj = Json.parseToJsonElement(json) as JsonObject
+            obj.mapValues { it.value.jsonPrimitive.content }
+        } else {
+            emptyMap()
+        }
+    }
+
+    fun resolve(logicalName: String): String = entries[logicalName] ?: logicalName
+}

--- a/src/main/kotlin/dev/fathony/tired/components/Icon.kt
+++ b/src/main/kotlin/dev/fathony/tired/components/Icon.kt
@@ -1,6 +1,7 @@
 package dev.fathony.tired.components
 
 import Icons
+import dev.fathony.tired.assets.AssetManifest
 import kotlinx.html.*
 
 sealed class SvgPaint {
@@ -59,7 +60,7 @@ fun FlowContent.icon(
             |stroke-linecap="${strokeLinecap.value}"
             |stroke-linejoin="${strokeLinejoin.value}"
             |$classAttr>
-            |<use href="/icons.svg#${icon.lucideIcon}"></use>
+            |<use href="/${AssetManifest.resolve("icons.svg")}#${icon.lucideIcon}"></use>
             |</svg>
         """.trimMargin()
             .replace(Regex("\n\\s*"), " ")

--- a/src/main/kotlin/dev/fathony/tired/layout/Layout.kt
+++ b/src/main/kotlin/dev/fathony/tired/layout/Layout.kt
@@ -1,5 +1,6 @@
 package dev.fathony.tired.layout
 
+import dev.fathony.tired.assets.AssetManifest
 import kotlinx.html.*
 
 fun HTML.layout(
@@ -13,8 +14,8 @@ fun HTML.layout(
         meta(charset = "utf-8")
         meta(name = "viewport", content = "width=device-width, initial-scale=1")
         title { name?.let { +it } }
-        if (css) link(rel = "stylesheet", href = "stylesheet.css")
-        if (js) script(src = "index.js") { defer = true }
+        if (css) link(rel = "stylesheet", href = AssetManifest.resolve("stylesheet.css"))
+        if (js) script(src = AssetManifest.resolve("index.js")) { defer = true }
     }
     body {
         content()

--- a/web-assets/scripts/build-css.js
+++ b/web-assets/scripts/build-css.js
@@ -1,5 +1,7 @@
 const postcss = require("postcss");
-const { readFile, writeFile, mkdir, rm } = require("fs/promises");
+const { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } = require("fs");
+const crypto = require("crypto");
+const path = require("path");
 const config = require("../postcss.config");
 
 const minify = process.argv.includes("--minify");
@@ -7,22 +9,37 @@ const outdirFlag = process.argv.indexOf("--outdir");
 const outdir =
   outdirFlag !== -1 ? process.argv[outdirFlag + 1] : "dist/stylesheets";
 
-async function build() {
-  await rm(outdir, { recursive: true, force: true });
-  await mkdir(outdir, { recursive: true });
+const manifestPath = path.resolve(__dirname, "../dist/manifest.json");
 
-  const input = await readFile("src/stylesheet.css", "utf8");
+async function build() {
+  rmSync(outdir, { recursive: true, force: true });
+  mkdirSync(outdir, { recursive: true });
+
+  const input = readFileSync("src/stylesheet.css", "utf8");
   const result = await postcss(config.plugins).process(input, {
     from: "src/stylesheet.css",
     to: `${outdir}/stylesheet.css`,
     map: minify ? false : { inline: false },
   });
 
-  await writeFile(`${outdir}/stylesheet.css`, result.css);
+  const hash = crypto
+    .createHash("md5")
+    .update(result.css)
+    .digest("hex")
+    .slice(0, 8);
+  const hashedName = `stylesheet-${hash}.css`;
+
+  writeFileSync(`${outdir}/${hashedName}`, result.css);
 
   if (!minify && result.map) {
-    await writeFile(`${outdir}/stylesheet.css.map`, result.map.toString());
+    writeFileSync(`${outdir}/${hashedName}.map`, result.map.toString());
   }
+
+  const manifest = existsSync(manifestPath)
+    ? JSON.parse(readFileSync(manifestPath, "utf8"))
+    : {};
+  manifest["stylesheet.css"] = hashedName;
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 }
 
 build();

--- a/web-assets/scripts/build-css.js
+++ b/web-assets/scripts/build-css.js
@@ -1,5 +1,11 @@
 const postcss = require("postcss");
-const { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } = require("fs");
+const {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+} = require("fs");
 const crypto = require("crypto");
 const path = require("path");
 const config = require("../postcss.config");

--- a/web-assets/scripts/build-icons.js
+++ b/web-assets/scripts/build-icons.js
@@ -11,7 +11,7 @@ const paths = icons
 
 execSync(
   `npx svg-sprite --symbol --symbol-dest=dist/icons --symbol-sprite=icons.svg ${paths}`,
-  { stdio: "inherit" },
+  { stdio: "inherit" }
 );
 
 const svgContent = readFileSync("dist/icons/icons.svg", "utf8");

--- a/web-assets/scripts/build-icons.js
+++ b/web-assets/scripts/build-icons.js
@@ -1,4 +1,7 @@
 const { execSync } = require("child_process");
+const { readFileSync, renameSync, writeFileSync, existsSync } = require("fs");
+const crypto = require("crypto");
+const path = require("path");
 
 const icons = process.argv[2].split(",");
 
@@ -8,5 +11,22 @@ const paths = icons
 
 execSync(
   `npx svg-sprite --symbol --symbol-dest=dist/icons --symbol-sprite=icons.svg ${paths}`,
-  { stdio: "inherit" }
+  { stdio: "inherit" },
 );
+
+const svgContent = readFileSync("dist/icons/icons.svg", "utf8");
+const hash = crypto
+  .createHash("md5")
+  .update(svgContent)
+  .digest("hex")
+  .slice(0, 8);
+const hashedName = `icons-${hash}.svg`;
+
+renameSync("dist/icons/icons.svg", `dist/icons/${hashedName}`);
+
+const manifestPath = path.resolve(__dirname, "../dist/manifest.json");
+const manifest = existsSync(manifestPath)
+  ? JSON.parse(readFileSync(manifestPath, "utf8"))
+  : {};
+manifest["icons.svg"] = hashedName;
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));

--- a/web-assets/scripts/build-js.js
+++ b/web-assets/scripts/build-js.js
@@ -1,15 +1,31 @@
 const esbuild = require("esbuild");
+const { writeFileSync, readFileSync, existsSync } = require("fs");
+const path = require("path");
 
 const minify = process.argv.includes("--minify");
 const outdirFlag = process.argv.indexOf("--outdir");
 const outdir =
   outdirFlag !== -1 ? process.argv[outdirFlag + 1] : "dist/scripts";
 
-esbuild.buildSync({
+const manifestPath = path.resolve(__dirname, "../dist/manifest.json");
+
+const result = esbuild.buildSync({
   entryPoints: ["src/index.js"],
   bundle: true,
   minify,
   sourcemap: !minify,
   target: "es2020",
   outdir,
+  entryNames: "[name]-[hash]",
+  metafile: true,
 });
+
+const outputs = Object.keys(result.metafile.outputs);
+const jsFile = outputs.find((f) => f.endsWith(".js") && !f.endsWith(".map"));
+const jsBasename = path.basename(jsFile);
+
+const manifest = existsSync(manifestPath)
+  ? JSON.parse(readFileSync(manifestPath, "utf8"))
+  : {};
+manifest["index.js"] = jsBasename;
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));


### PR DESCRIPTION
## Summary
- Asset build scripts (JS, CSS, SVG) now output content-hashed filenames (e.g., `index-A3F9B2.js`, `stylesheet-a47a08e2.css`)
- A `manifest.json` maps logical names to hashed filenames, read at startup by `AssetManifest`
- Layout and icon component resolve assets through the manifest
- Manifest is internal-only (not served publicly via HTTP)
- Browsers will cache assets indefinitely but always fetch the correct version after deploys

## Test plan
- [ ] Run the app and verify page loads with hashed asset URLs in the HTML source
- [ ] Verify CSS, JS, and SVG icons all load correctly
- [ ] Verify `/manifest.json` returns 404 (not publicly accessible)
- [ ] Change a source file, rebuild, and confirm the hash changes