### PR TITLE
Use FORMAT_PAT to trigger CI on auto-format commits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FORMAT_PAT }}
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }} --depth=1
       - uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- Switches the lint workflow checkout from `GITHUB_TOKEN` to `FORMAT_PAT`
- Commits pushed by `GITHUB_TOKEN` don't trigger workflows, so auto-format commits left PRs with no checks and blocked merging
- With a PAT, the format-fix commit triggers a new workflow run, and branch protection checks pass

## Test plan
- [ ] Open a PR with a formatting violation
- [ ] Verify the auto-format commit triggers a second CI run
- [ ] Verify the PR becomes mergeable after CI passes