### PR TITLE
Add npmInstallPackage Gradle task

### DIFF
--- a/gradle/plugins/src/main/kotlin/tired.web-assets.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/tired.web-assets.gradle.kts
@@ -13,6 +13,11 @@ node {
 val isDev = gradle.startParameter.taskNames.any { it == "run" || it.endsWith(":run") }
 val distDir = if (isDev) "dist/dev" else "dist/prod"
 
+val npmInstallPackage by tasks.registering(NpmTask::class) {
+    dependsOn(tasks.named("npmSetup"))
+    args = listOf("install", "--save", project.findProperty("package")?.toString() ?: "")
+}
+
 val npmBuildCss by tasks.registering(NpmTask::class) {
     dependsOn(tasks.named("npmInstall"))
     args = buildList {


### PR DESCRIPTION
## Summary

- Adds `npmInstallPackage` task to `tired.web-assets.gradle.kts` for installing npm packages on demand

## Usage

```
./gradlew npmInstallPackage -Ppackage=<package-name>
```

## Test plan

- [x] Run `./gradlew npmInstallPackage -Ppackage=lodash` and verify it installs the package and updates `package.json`