### PR TITLE
Fix ktlint implicit dependency on copyIcons and exclude generated sources

### DIFF
--- a/gradle/plugins/src/main/kotlin/Icons.kt
+++ b/gradle/plugins/src/main/kotlin/Icons.kt
@@ -1,4 +1,6 @@
-enum class Icons(val lucideIcon: String) {
+enum class Icons(
+    val lucideIcon: String,
+) {
     Chevron("chevron-down"),
     Search("search"),
     ShoppingCart("shopping-cart"),

--- a/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/tired.ktor-app.gradle.kts
@@ -56,8 +56,18 @@ tasks.named("compileKotlin") {
     dependsOn(copyIcons)
 }
 
+tasks.named("runKtlintCheckOverMainSourceSet") {
+    dependsOn(copyIcons)
+}
+
 tasks.test {
     useJUnitPlatform()
+}
+
+ktlint {
+    filter {
+        exclude { element -> element.file.path.contains("/build/generated/") }
+    }
 }
 
 val diffBase = project.findProperty("diffBase")?.toString()


### PR DESCRIPTION
## Summary

- Declare `runKtlintCheckOverMainSourceSet` as depending on `copyIcons` to satisfy Gradle's task ordering validation (the generated dir is registered as a main source set input)
- Exclude `build/generated/` from ktlint so the copied `Icons.kt` is not linted — the source file is already linted in the `plugins` subproject where it lives
- Fix `Icons.kt` formatting to comply with ktlint's multi-line constructor parameter style

## Test plan

- [ ] Run `./gradlew build` and verify BUILD SUCCESSFUL
- [ ] Run `./gradlew check` and verify ktlint passes without linting `build/generated/kotlin/Icons.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)